### PR TITLE
fix error when target path doesn't exist

### DIFF
--- a/air_link/package.py
+++ b/air_link/package.py
@@ -50,6 +50,7 @@ def remove_package(path: Path) -> None:
 async def install_package(path: Path) -> None:
     logging.info(f'Extracting {path}...')
     target = Path(app.storage.general['target_directory']).expanduser()
+    target.mkdir(exist_ok=True)
     shutil.rmtree(target)
     with zipfile.ZipFile(path, 'r') as zip_ref:
         members = zip_ref.infolist()


### PR DESCRIPTION
In #4 we fixed the `FileNotFoundError` when `~/robot` (the target directory) didn't exist. Now we made this customizable in #7 and have the `FileNotFoundError` again. This PR creates the target directory before deleting it.