### PR TITLE
Read and save env variables outside of installing a package

### DIFF
--- a/air_link/main_page.py
+++ b/air_link/main_page.py
@@ -1,7 +1,7 @@
 from nicegui import app, ui
 
 from .authorized_keys import AuthorizedKeysDialog
-from .package import add_package, show_packages
+from .package import add_package, get_target_folder, read_env, show_packages, write_env
 from .system import docker_prune_preview, show_disk_space
 
 
@@ -27,7 +27,12 @@ def create_page() -> None:
                 .tooltip('Restart Air Link') \
                 .props('flat round color=white')
 
-        ui.label('Environment variables').classes('text-2xl')
+        with ui.row():
+            ui.label('Environment variables').classes('text-2xl')
+            ui.button(icon='refresh', on_click=lambda: read_env(get_target_folder())) \
+                .props('flat outline').tooltip('Load environment variables')
+            ui.button(icon='save', on_click=lambda: write_env(get_target_folder())) \
+                .props('flat outline').tooltip('Save environment variables')
         ui.codemirror().bind_value(app.storage.general, 'env').classes('h-32 border')
 
         ui.label('Packages').classes('text-2xl')

--- a/air_link/package.py
+++ b/air_link/package.py
@@ -24,11 +24,16 @@ def write_env(target_folder: Path) -> None:
 
 
 def read_env(target_folder: Path) -> None:
-    app.storage.general['env'] = Path(target_folder / '.env').read_text()
+    file_path = Path(target_folder / '.env')
+    if not file_path.exists():
+        file_path.touch()
+    app.storage.general['env'] = file_path.read_text()
 
 
 def get_target_folder() -> Path:
-    return Path(app.storage.general['target_directory']).expanduser()
+    target_folder = Path(app.storage.general['target_directory']).expanduser()
+    target_folder.mkdir(exist_ok=True)
+    return target_folder
 
 
 @ui.refreshable
@@ -62,7 +67,6 @@ def remove_package(path: Path) -> None:
 async def install_package(path: Path) -> None:
     logging.info(f'Extracting {path}...')
     target = get_target_folder()
-    target.mkdir(exist_ok=True)
     shutil.rmtree(target)
     with zipfile.ZipFile(path, 'r') as zip_ref:
         members = zip_ref.infolist()

--- a/air_link/run.py
+++ b/air_link/run.py
@@ -3,6 +3,7 @@ import logging
 from nicegui import app, ui
 
 from .main_page import create_page
+from .package import get_target_folder, read_env
 from .ssh import setup
 
 
@@ -14,6 +15,7 @@ def run() -> None:
     if on_air:
         app.on_startup(setup)
 
+    read_env(get_target_folder())
     create_page()
 
     ui.run(title='Air Link', favicon='⛑', reload=False, on_air=on_air)


### PR DESCRIPTION
The environment variables were only saved while installing a new package and were actually never read from the system.
This PR reads them on startup and allows the user to load and save them manually.

Note: I'm totally not happy with the functions `write_env`, `read_env`, `get_target_folder`, but they avoid duplicate code and allow saving and loading from buttons.