### PR TITLE
Fix missing installation directory

### DIFF
--- a/air_link/main_page.py
+++ b/air_link/main_page.py
@@ -37,7 +37,7 @@ def create_page() -> None:
 
         ui.label('Packages').classes('text-2xl')
         ui.input('Installation directory', value=app.storage.general.get('target_directory', ''),
-                 placeholder='~/robot').bind_value_to(app.storage.general, 'target_directory')
+                 placeholder='~/robot').bind_value(app.storage.general, 'target_directory')
         show_packages()
         upload = ui.upload(auto_upload=True, on_upload=add_package).props('accept=.zip').classes('hidden')
         ui.button('Upload package', icon='upload', on_click=lambda: upload.run_method('pickFiles')).props('outline')

--- a/air_link/main_page.py
+++ b/air_link/main_page.py
@@ -1,7 +1,7 @@
 from nicegui import app, ui
 
 from .authorized_keys import AuthorizedKeysDialog
-from .package import add_package, show_packages
+from .package import add_package, get_target_folder, read_env, show_packages, write_env
 from .system import docker_prune_preview, show_disk_space
 
 
@@ -27,7 +27,12 @@ def create_page() -> None:
                 .tooltip('Restart Air Link') \
                 .props('flat round color=white')
 
-        ui.label('Environment variables').classes('text-2xl')
+        with ui.row():
+            ui.label('Environment variables').classes('text-2xl')
+            ui.button(icon='refresh', on_click=lambda: read_env(get_target_folder())) \
+                .props('flat outline').tooltip('Load environment variables')
+            ui.button(icon='save', on_click=lambda: write_env(get_target_folder())) \
+                .props('flat outline').tooltip('Save environment variables')
         ui.codemirror().bind_value(app.storage.general, 'env').classes('h-32 border')
 
         ui.label('Packages').classes('text-2xl')

--- a/air_link/main_page.py
+++ b/air_link/main_page.py
@@ -1,7 +1,7 @@
 from nicegui import app, ui
 
 from .authorized_keys import AuthorizedKeysDialog
-from .package import add_package, get_target_folder, read_env, show_packages, write_env
+from .package import add_package, read_env, show_packages, write_env
 from .system import docker_prune_preview, show_disk_space
 
 
@@ -29,14 +29,15 @@ def create_page() -> None:
 
         with ui.row():
             ui.label('Environment variables').classes('text-2xl')
-            ui.button(icon='refresh', on_click=lambda: read_env(get_target_folder())) \
+            ui.button(icon='refresh', on_click=read_env) \
                 .props('flat outline').tooltip('Load environment variables')
-            ui.button(icon='save', on_click=lambda: write_env(get_target_folder())) \
+            ui.button(icon='save', on_click=write_env) \
                 .props('flat outline').tooltip('Save environment variables')
         ui.codemirror().bind_value(app.storage.general, 'env').classes('h-32 border')
 
         ui.label('Packages').classes('text-2xl')
-        ui.input('Installation directory', value='~/robot').bind_value_to(app.storage.general, 'target_directory')
+        ui.input('Installation directory', value=app.storage.general.get('target_directory', ''),
+                 placeholder='~/robot').bind_value_to(app.storage.general, 'target_directory')
         show_packages()
         upload = ui.upload(auto_upload=True, on_upload=add_package).props('accept=.zip').classes('hidden')
         ui.button('Upload package', icon='upload', on_click=lambda: upload.run_method('pickFiles')).props('outline')

--- a/air_link/package.py
+++ b/air_link/package.py
@@ -24,11 +24,16 @@ def write_env(target_folder: Path) -> None:
 
 
 def read_env(target_folder: Path) -> None:
-    app.storage.general['env'] = Path(target_folder / '.env').read_text()
+    file_path = Path(target_folder / '.env')
+    if not file_path.exists():
+        file_path.touch()
+    app.storage.general['env'] = file_path.read_text()
 
 
 def get_target_folder() -> Path:
-    return Path(app.storage.general['target_directory']).expanduser()
+    target_folder = Path(app.storage.general['target_directory']).expanduser()
+    target_folder.mkdir(exist_ok=True)
+    return target_folder
 
 
 @ui.refreshable
@@ -62,7 +67,6 @@ def remove_package(path: Path) -> None:
 async def install_package(path: Path) -> None:
     logging.info(f'Extracting {path}...')
     target = get_target_folder()
-    target.mkdir(exist_ok=True)
     shutil.rmtree(target)
     with zipfile.ZipFile(path, 'r') as zip_ref:
         members = zip_ref.infolist()

--- a/air_link/package.py
+++ b/air_link/package.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 import zipfile
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from nicegui import app, events, run, ui
 
@@ -19,7 +19,7 @@ def sorted_nicely(paths: List[Path]) -> List[Path]:
     return sorted(paths, key=lambda path: [int(c) if c.isdigit() else c for c in re.split('([0-9]+)', path.stem)])
 
 
-def get_target_folder() -> Path | None:
+def get_target_folder() -> Optional[Path]:
     target_folder_name = app.storage.general.get('target_directory', False)
     if not target_folder_name:
         return None
@@ -28,7 +28,7 @@ def get_target_folder() -> Path | None:
 
 
 def write_env() -> None:
-    target_folder: Path | None = get_target_folder()
+    target_folder = get_target_folder()
     if target_folder is None:
         ui.notify('Please set the installation directory first', type='negative')
         return
@@ -37,7 +37,7 @@ def write_env() -> None:
 
 
 def read_env() -> None:
-    target_folder: Path | None = get_target_folder()
+    target_folder = get_target_folder()
     if target_folder is None:
         ui.notify('Please set the installation directory first', type='negative')
         return

--- a/air_link/run.py
+++ b/air_link/run.py
@@ -3,7 +3,7 @@ import logging
 from nicegui import app, ui
 
 from .main_page import create_page
-from .package import get_target_folder, read_env
+from .package import read_env
 from .ssh import setup
 
 
@@ -15,7 +15,6 @@ def run() -> None:
     if on_air:
         app.on_startup(setup)
 
-    read_env(get_target_folder())
     create_page()
-
+    app.on_startup(read_env)
     ui.run(title='Air Link', favicon='⛑', reload=False, on_air=on_air)

--- a/air_link/run.py
+++ b/air_link/run.py
@@ -3,6 +3,7 @@ import logging
 from nicegui import app, ui
 
 from .main_page import create_page
+from .package import get_target_folder, read_env
 from .ssh import setup
 
 
@@ -14,6 +15,7 @@ def run() -> None:
     if on_air:
         app.on_startup(setup)
 
+    read_env(get_target_folder())
     create_page()
 
     ui.run(title='Air Link', favicon='⛑', reload=False, on_air=on_air)


### PR DESCRIPTION
Air-Link currently can't be installed on a new system with the latest release [0.3.0](https://github.com/zauberzeug/air-link/releases/tag/v0.3.0), because it wants to read the environment variables on startup even when the installation directory doesn't exist yet.

```
Sep 18 13:22:44 rb34 env[4057]: Traceback (most recent call last):
Sep 18 13:22:44 rb34 env[4057]:  File "/home/zauberzeug/.local/bin/air-link", line 8, in <module>
Sep 18 13:22:44 rb34 env[4057]:   sys.exit(main())
Sep 18 13:22:44 rb34 env[4057]:  File "/home/zauberzeug/.local/lib/python3.8/site-packages/air_link/main.py", line 14, in main
Sep 18 13:22:44 rb34 env[4057]:   run()
Sep 18 13:22:44 rb34 env[4057]:  File "/home/zauberzeug/.local/lib/python3.8/site-packages/air_link/run.py", line 18, in run
Sep 18 13:22:44 rb34 env[4057]:   read_env(get_target_folder())
Sep 18 13:22:44 rb34 env[4057]:  File "/home/zauberzeug/.local/lib/python3.8/site-packages/air_link/package.py", line 34, in get_target_folder
Sep 18 13:22:44 rb34 env[4057]:   target_folder = Path(app.storage.general['target_directory']).expanduser()
Sep 18 13:22:44 rb34 env[4057]: KeyError: 'target_directory' 
```

ToDo:

- [x] Check if installing a package still works. I had permission problems with my local setup
- [ ] Install on a fresh system 