### PR TITLE
Storage initialisation patch 

### DIFF
--- a/air_link/run.py
+++ b/air_link/run.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 from nicegui import app, ui
@@ -11,7 +12,7 @@ def run() -> None:
     logging.basicConfig(level=logging.INFO)
     logging.getLogger('watchfiles').setLevel(logging.WARNING)
     logging.getLogger('nicegui.air').setLevel(logging.DEBUG)
-
+    asyncio.run(app.storage.general.initialize())
     on_air = app.storage.general.get('air_link_token', False)
     if on_air:
         app.on_startup(ssh.setup)


### PR DESCRIPTION
With [NiceGUI version > 2.10.](https://github.com/zauberzeug/nicegui/releases/tag/v2.10.0) there is currently a bug that leads to a late initialisation of the store. As a result, the Air-Link Token can not be loaded. 

This PR adds a workaround to initialise the store itself, as suggested in [NiceGUI issue #4352](https://github.com/zauberzeug/nicegui/issues/4352) until a new release fixes the issue. 