### PR TITLE
Use the non-common port 4230 as default, but make it configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The edge device needs to run a Linux-based OS and have Python >=3.8 installed.
 
 ### 1. Install the Air Link app on an edge device
 
-Air link can be installed using pip.
+Air Link should be installed using pip.
 To run the app automatically after a reboot, you can install it as a system service using its `install` command.
 
 ```bash
@@ -53,17 +53,17 @@ pip install air-link
 air-link install [<on air token>]
 ```
 
-The app is accessible on port 8080 and can be reached via the IP address of the edge device.
+After that, Air Link is accessible via the IP address of the edge device on default port 4230 (http://localhost:4230).
 If you have provided an On Air token, the app is also accessible via NiceGUI On Air (see below).
 
 > [!NOTE]
 > To make the app accessible over an SSH tunnel, you can log into the edge device with the following command:
 >
 > ```bash
-> ssh -L 8888:localhost:8080 <target device>
+> ssh -L 8888:localhost:4230 <target device>
 > ```
 >
-> The app will then be reachable at `localhost:8888` on the developer machine.
+> The app will then be reachable at `localhost:8888` on your developer machine.
 
 > [!TIP]
 > To display the logs of the Air Link service, use the following command:
@@ -83,7 +83,7 @@ To make the Air Link app accessible via NiceGUI On Air, follow these three steps
     Alternatively, you can enter the token in the top right corner of the Air Link web interface.
 3.  Restart the Air Link service using `systemctl restart air-link.service` or the button on the top right corner of the Air Link web interface.
 
-Air Link will be reachable through the URL provided by NiceGUI On Air, for example <https://europe.on-air.io/zauberzeug/rodja-air-link>.
+Air Link will be reachable through the URL provided by NiceGUI On Air, for example <https://europe.on-air.io/zauberzeug/demo-air-link>.
 We strongly suggest to set a fixed region for the device at <https://on-air.nicegui.io> to keep the URL stable.
 
 ### 3. Manage SSH keys (optional)

--- a/air_link/main.py
+++ b/air_link/main.py
@@ -16,7 +16,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.action == 'run':
-        port = args.port or app.storage.general.get('air_link_port', 7456)
+        port = args.port or app.storage.general.get('air_link_port', 4230)
         run(port=port)
 
     if args.action == 'install':

--- a/air_link/main.py
+++ b/air_link/main.py
@@ -12,11 +12,11 @@ def main() -> None:
     parser.add_argument('action', choices=['install', 'run', 'set-token'], help='action to perform', default='run')
     parser.add_argument('token', nargs='?',
                         help='On Air token for remote access (used with "install" or "set-token" actions)')
-    parser.add_argument('--port', type=int, help='Port where the app should be launched')
+    parser.add_argument('--port', type=int, help='Port where the app should be launched (default: 4230)')
     args = parser.parse_args()
 
     if args.action == 'run':
-        port = args.port or app.storage.general.get('air_link_port')
+        port = args.port or app.storage.general.get('air_link_port', 7456)
         run(port=port)
 
     if args.action == 'install':

--- a/air_link/main.py
+++ b/air_link/main.py
@@ -12,18 +12,24 @@ def main() -> None:
     parser.add_argument('action', choices=['install', 'run', 'set-token'], help='action to perform', default='run')
     parser.add_argument('token', nargs='?',
                         help='On Air token for remote access (used with "install" or "set-token" actions)')
+    parser.add_argument('--port', type=int, help='Port where the app should be launched')
     args = parser.parse_args()
 
     if args.action == 'run':
-        run()
+        port = args.port or app.storage.general.get('air_link_port')
+        run(port=port)
 
     if args.action == 'install':
         if args.token:
             app.storage.general['air_link_token'] = args.token
+        if args.port:
+            app.storage.general['air_link_port'] = args.port
         install()
         print('Installation complete.')
         if args.token:
             print('Token is saved.')
+        if args.port:
+            print('Port is saved.')
 
     if args.action == 'set-token':
         if not args.token:

--- a/air_link/run.py
+++ b/air_link/run.py
@@ -7,7 +7,7 @@ from .main_page import create_page
 from .package import read_env
 
 
-def run() -> None:
+def run(port=None) -> None:
     logging.basicConfig(level=logging.INFO)
     logging.getLogger('watchfiles').setLevel(logging.WARNING)
     logging.getLogger('nicegui.air').setLevel(logging.DEBUG)
@@ -20,4 +20,4 @@ def run() -> None:
 
     create_page()
     app.on_startup(read_env)
-    ui.run(title='Air Link', favicon='⛑', reload=False, on_air=on_air, show=False)
+    ui.run(title='Air Link', favicon='⛑', reload=False, on_air=on_air, show=False, port=port)

--- a/air_link/run.py
+++ b/air_link/run.py
@@ -7,7 +7,7 @@ from .main_page import create_page
 from .package import read_env
 
 
-def run(port=None) -> None:
+def run(port: int) -> None:
     logging.basicConfig(level=logging.INFO)
     logging.getLogger('watchfiles').setLevel(logging.WARNING)
     logging.getLogger('nicegui.air').setLevel(logging.DEBUG)


### PR DESCRIPTION
The old default port 8080 is commonly used and hence might prevent Air Link from starting. Therefore this PR uses 4230 as new default port and allows it to be changed via cli parameter.
NOTE: This is a breaking change.