### PR TITLE
Use .air-link storage path to not collide with other NiceGUI applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 .nicegui/
+.air-link/

--- a/main.py
+++ b/main.py
@@ -1,9 +1,23 @@
 #!/usr/bin/env python3
 import os
+import shutil
+from pathlib import Path
 
 from air_link import main
 
 os.environ['NICEGUI_STORAGE_PATH'] = '.air-link'
+
+old_storage_path = Path('.nicegui/general-storage.json')
+new_storage_path = Path('.air-link/general-storage.json')
+
+if old_storage_path.exists() and not new_storage_path.exists():
+    try:
+        new_storage_path.parent.mkdir(exist_ok=True)
+        shutil.copy(old_storage_path, new_storage_path)
+        print('Migrated storage from .nicegui to .air-link')
+    except Exception as e:
+        print(f'Error migrating storage: {e}')
+
 
 if __name__ == '__main__':
     main()

--- a/main.py
+++ b/main.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
+import os
+
 from air_link import main
+
+os.environ['NICEGUI_STORAGE_PATH'] = '.air-link'
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR sets the default storage path to `.air-link`. For migration the general storage from `.nicegui` is copied over.